### PR TITLE
Add binary predictions endpoint

### DIFF
--- a/online_inference/app.py
+++ b/online_inference/app.py
@@ -6,6 +6,9 @@ from fastapi import FastAPI, HTTPException, Request, status
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
+import os
+
+#sys.path.append(os.path.abspath("."))
 
 # Импортируем вспомогательные функции из data_utils
 from online_inference.data_utils import (
@@ -64,6 +67,24 @@ def predict(request: InputData):
     logger.info(msg=f"Prediction finished. It's OK :) {y_pred}")
     return OutputData(predicted_values=y_pred) # Возвращаем результат
 
+# Функция, которая получает данные в post-запросе и возвращает бинарный скор:
+# 1 - если вероятность, предсказанная моделью, превышает 0.6
+# 0 - в обратном случае
+
+@app.post("/will_it_rain", response_model=OutputData)
+def predict_rain(request: InputData):
+    data = get_data(request) # Парсим данные из запроса в DataFrame
+    logger.info(msg=f"Data loaded")
+    try:
+        y_pred = model_lgbm.predict_proba(data)[:, 1] # Получаем предикт
+        y_pred_binary = [int(y > 0.6) for y in y_pred]
+    except Exception as e:
+        raise HTTPException( # Если что-то идёт не так, выдаём ошибку и код 500
+            status_code=500,
+            detail="Error: something went wrong while binary prediction")
+
+    logger.info(msg=f"Binary prediction finished. It's OK :) {y_pred_binary}")
+    return OutputData(predicted_values=y_pred_binary) # Возвращаем результат
 
 # Функция, срабатывающая при ошибке парсинга данных
 # (если данные в post запросе имеют неправильный формат)

--- a/online_inference/script.py
+++ b/online_inference/script.py
@@ -13,10 +13,16 @@ def main(ip = "127.0.0.1", port = 8000):
         "features_names": dataset.columns.tolist(),
         "model": "lgbm",
     }
+#    response = requests.post(
+#        f"http://{ip}:{port}/predict",
+#        json=data_json,
+#    )
+
     response = requests.post(
-        f"http://{ip}:{port}/predict",
+        f"http://{ip}:{port}/will_it_rain",
         json=data_json,
     )
+
     print(f"Status code:\n{response.status_code}")
     print(f"Result:\n{response.json()}")
 

--- a/online_inference/tests.py
+++ b/online_inference/tests.py
@@ -88,14 +88,14 @@ class TestOnlineInference(unittest.TestCase):
             self.assertAlmostEqual(response.json()['predicted_values'][2], 0.71, delta=0.005)
 
     # Тест для /will_it_rain
-    # def test_will_it_rain_ok(self):
-    #     with TestClient(app) as client:
-    #         response = client.post("/will_it_rain", json=self.data_to_predict)
-    #         self.assertEqual(response.status_code, 200)
-    #         self.assertEqual(len(response.json()['predicted_values']), 3)
-    #         self.assertEqual(response.json()['predicted_values'][0], response.json()['predicted_values'][1])
-    #         self.assertEqual(response.json()['predicted_values'][0], 0.0)
-    #         self.assertEqual(response.json()['predicted_values'][2], 1.0)
+    def test_will_it_rain_ok(self):
+        with TestClient(app) as client:
+            response = client.post("/will_it_rain", json=self.data_to_predict)
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(len(response.json()['predicted_values']), 3)
+            self.assertEqual(response.json()['predicted_values'][0], response.json()['predicted_values'][1])
+            self.assertEqual(response.json()['predicted_values'][0], 0.0)
+            self.assertEqual(response.json()['predicted_values'][2], 1.0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
modified:   online_inference/app.py
    added decorator:
        @app.post("/will_it_rain", response_model=OutputData)
    added function:
        def predict_rain(request: InputData)
modified:   online_inference/script.py
    added request:
        requests.post(f"http://{ip}:{port}/will_it_rain", json=data_json)
modified:   online_inference/tests.py
    added method:
        def test_will_it_rain_ok(self):